### PR TITLE
[Feat 💡] AI일정(2) 최종

### DIFF
--- a/frontend/src/api/schedule/postMakeSchedule.ts
+++ b/frontend/src/api/schedule/postMakeSchedule.ts
@@ -1,0 +1,29 @@
+import { AxiosResponse } from 'axios'
+
+import { aiLearningAxios } from '../axiosInstance'
+
+interface SuccessResponse {
+  message: string
+}
+
+export const makeSchedule = async (
+  token: string,
+  duration: string[],
+  period: string[],
+  description: string,
+  places: string[],
+  style: string[],
+): Promise<AxiosResponse<SuccessResponse> | null> => {
+  const response = await aiLearningAxios.post(
+    'schedule/make',
+    {
+      duration,
+      period,
+      description,
+      places,
+      style,
+    },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response
+}

--- a/frontend/src/components/BackButton/styles/BackButton.style.tsx
+++ b/frontend/src/components/BackButton/styles/BackButton.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 export const StyledButton = styled.button`
+  position: fixed;
   width: 4rem;
   height: 3rem;
   background: transparent;

--- a/frontend/src/pages/AISchedule2Page/AISchedule2.tsx
+++ b/frontend/src/pages/AISchedule2Page/AISchedule2.tsx
@@ -1,26 +1,47 @@
-import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import * as L from './styles/AISchedule2.style'
+import { makeSchedule } from '../../api/schedule/postMakeSchedule'
 import BackButton from '../../components/BackButton/BackButton'
 import { useScheduleStore } from '../../stores/useScheduleStore'
 
 const AISchedule2 = () => {
-  const { startDate, endDate, frequency, dates, location, travelStyle } =
+  const token = localStorage.getItem('token')
+  const navigate = useNavigate()
+
+  const { startDate, endDate, dates, location, travelStyle } =
     useScheduleStore()
 
-  console.log('Received Schedule State from Zustand:', {
-    startDate,
-    endDate,
-    dates,
-    frequency,
-    location,
-    travelStyle,
-  })
-  const [description, setDescription] = useState<string>('')
+  const { description, setDescription } = useScheduleStore(state => ({
+    description: state.description,
+    setDescription: state.setDescription,
+  }))
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const { value } = e.target
-    setDescription(value)
+  const handleSubmitAIInput = async () => {
+    console.log('Received Schedule State from Zustand:', {
+      startDate,
+      endDate,
+      dates,
+      location,
+      travelStyle,
+      description,
+    })
+
+    const duration = [startDate, endDate]
+    if (token) {
+      const successResponse = await makeSchedule(
+        token,
+        duration,
+        dates,
+        description,
+        location,
+        travelStyle,
+      )
+
+      if (successResponse && successResponse.data) {
+        navigate('/ai-schedule-step3')
+      }
+    }
   }
 
   return (
@@ -38,12 +59,12 @@ const AISchedule2 = () => {
           name='ai-Input2'
           id='ai-Input2'
           value={description}
-          onChange={handleChange}
+          onChange={e => setDescription(e.target.value)}
           maxLength={300}
           placeholder='예시) 4, 5월엔 멀리 이동이 어려울 거 같아, 서울 내 장소로만 추천해주세요!'
         />
       </L.Container>
-      <L.BottomButton>완료</L.BottomButton>
+      <L.BottomButton onClick={handleSubmitAIInput}>완료</L.BottomButton>
     </>
   )
 }

--- a/frontend/src/pages/AISchedule2Page/styles/AISchedule2.style.tsx
+++ b/frontend/src/pages/AISchedule2Page/styles/AISchedule2.style.tsx
@@ -3,11 +3,12 @@ import styled from 'styled-components'
 export const Container = styled.div`
   box-sizing: border-box;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 5rem); /* BackButton 높이만큼 빼기 */
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
   padding: 2rem;
+  padding-top: 6rem; /* BackButton 높이만큼 추가 */
 `
 
 export const Title = styled.div`

--- a/frontend/src/pages/AISchedule2Page/styles/AISchedule2.style.tsx
+++ b/frontend/src/pages/AISchedule2Page/styles/AISchedule2.style.tsx
@@ -35,6 +35,7 @@ export const InputBox = styled.textarea`
   background-color: #f4f4f4;
   box-sizing: border-box;
   overflow: auto;
+  font-size: 0.9rem;
   text-align: left;
   line-height: 1.5;
 `

--- a/frontend/src/pages/AISchedule3Page/AISchedule3.tsx
+++ b/frontend/src/pages/AISchedule3Page/AISchedule3.tsx
@@ -1,0 +1,19 @@
+import * as L from './styles/AISchedule3.style'
+import BackButton from '../../components/BackButton/BackButton'
+
+const AISchedule3 = () => {
+  return (
+    <>
+      <BackButton />
+      <L.Container>
+        <L.Title>
+          <L.Text>완성된 플랜이에요!</L.Text>
+          <L.Text>전체 일정을 확인해보세요!</L.Text>
+        </L.Title>
+      </L.Container>
+      <L.BottomButton>완료</L.BottomButton>
+    </>
+  )
+}
+
+export default AISchedule3

--- a/frontend/src/pages/AISchedule3Page/styles/AISchedule3.style.tsx
+++ b/frontend/src/pages/AISchedule3Page/styles/AISchedule3.style.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  height: calc(100vh - 5rem); /* BackButton 높이만큼 빼기 */
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  padding: 2rem;
+  padding-top: 6rem; /* BackButton 높이만큼 추가 */
+`
+
+export const Title = styled.div`
+  line-height: 2rem;
+  margin-bottom: 2rem;
+`
+
+export const Text = styled.p`
+  font-size: 1.3rem;
+  font-weight: 700;
+`
+
+export const BottomButton = styled.button`
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 3rem);
+  max-width: 352px;
+  height: 46px;
+  border-radius: 8px;
+  border: none;
+  font-size: 16px;
+  color: white;
+  font-weight: 600;
+  background-color: #525fd4;
+  cursor: pointer;
+  box-sizing: border-box;
+  &:hover {
+    background-color: #434cb1;
+  }
+`

--- a/frontend/src/pages/CalendarPage/Calendar.tsx
+++ b/frontend/src/pages/CalendarPage/Calendar.tsx
@@ -1,9 +1,25 @@
+import { FaWandMagicSparkles } from 'react-icons/fa6'
+import { useNavigate } from 'react-router-dom'
+
+import * as L from './styles/Calendar.style'
 import BottomMenuBar from '../../components/BottomMenuBar/BottomMenuBar'
 
 const Calendar = () => {
+  const navigate = useNavigate()
+
+  const handleComplete = () => {
+    navigate('/ai-schedule-step1')
+  }
+
   return (
     <>
-      Calendar Page
+      <L.HeaderSection>
+        Calendar Page
+        <L.AIScheduleButton onClick={handleComplete}>
+          <FaWandMagicSparkles />
+          &nbsp;&nbsp;AI 교육여행
+        </L.AIScheduleButton>
+      </L.HeaderSection>
       <BottomMenuBar />
     </>
   )

--- a/frontend/src/pages/CalendarPage/styles/Calendar.style.tsx
+++ b/frontend/src/pages/CalendarPage/styles/Calendar.style.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+export const HeaderSection = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+`
+
+export const AIScheduleButton = styled.button`
+  height: 1.7rem;
+  padding: 0 1rem;
+  border: none;
+  border-radius: 1rem;
+  background-color: #3a3a3a;
+  color: white;
+  font-size: 0.7rem;
+  margin-left: auto;
+
+  &:hover {
+    background-color: black;
+  }
+`

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from 'react-router-dom'
 import App from './App'
 import AISchedule1 from './pages/AISchedule1Page/AISchedule1'
 import AISchedule2 from './pages/AISchedule2Page/AISchedule2'
+import AISchedule3 from './pages/AISchedule3Page/AISchedule3'
 import Calendar from './pages/CalendarPage/Calendar'
 import Login from './pages/LoginPage/Login'
 import Profile from './pages/ProfilePage/Profile'
@@ -51,6 +52,10 @@ const router = createBrowserRouter([
       {
         path: 'ai-schedule-step2',
         element: <AISchedule2 />,
+      },
+      {
+        path: 'ai-schedule-step3',
+        element: <AISchedule3 />,
       },
       {
         path: 'test',


### PR DESCRIPTION
## #️⃣연관된 이슈

close #17 

## 💡 핵심적으로 구현된 사항

![image](https://github.com/user-attachments/assets/2b668ff8-4438-4af3-a745-94d7218a7e49)
- 캘린더 화면에서 AI일정 페이지로 이동할 수 있게 연결

![image](https://github.com/user-attachments/assets/c5d2587b-469e-42bd-beec-5189208eed19)
- AI일정(1)과 AI일정(2) 작성내용 합쳐 post 요청 보내게끔 함

![image](https://github.com/user-attachments/assets/d3381149-f9fb-451c-af1c-2398a88b40eb)
- api 요청 성공 시 이동화면 연결

## ➕ 그 외에 추가적으로 구현된 사항

- 뒤로 가기 버튼 fixed 형태로 고정시킴

## 🤔 테스트,검증 && 고민 사항

### 📌 PR Comment 작성 시 Prefix for Reviewers