### PR TITLE
[Design 🎨] BottomMenuBar 디자인 및 경고 수정

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,10 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <!-- <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" /> -->
     <!-- <link rel="icon" href="%PUBLIC_URL%/favicon.ico" /> -->
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/frontend/src/components/BottomMenuBar/BottomMenuBar.tsx
+++ b/frontend/src/components/BottomMenuBar/BottomMenuBar.tsx
@@ -56,7 +56,7 @@ const BottomNav: React.FC = () => {
           <MenuIcon className='menu-icon'>
             <Icon
               icon={icon.icon}
-              style={{ fontSize: '24px', color: 'currentColor' }}
+              style={{ fontSize: '20px', color: 'currentColor' }}
             />
             <span>{icon.label}</span>
           </MenuIcon>

--- a/frontend/src/components/BottomMenuBar/BottomMenuBar.tsx
+++ b/frontend/src/components/BottomMenuBar/BottomMenuBar.tsx
@@ -1,5 +1,3 @@
-// BottomMenuBar.tsx
-
 import calendarIcon from '@iconify/icons-heroicons/calendar-solid'
 import profileIcon from '@iconify/icons-heroicons/user-20-solid'
 import rankingIcon from '@iconify/icons-icon-park-solid/five-star-badge'
@@ -55,15 +53,13 @@ const BottomNav: React.FC = () => {
           className={({ isActive }) => (isActive ? 'active' : '')}
           end
         >
-          {({ isActive }) => (
-            <MenuIcon isActive={isActive}>
-              <Icon
-                icon={icon.icon}
-                style={{ fontSize: '24px', color: 'currentColor' }}
-              />
-              <span>{icon.label}</span>
-            </MenuIcon>
-          )}
+          <MenuIcon className='menu-icon'>
+            <Icon
+              icon={icon.icon}
+              style={{ fontSize: '24px', color: 'currentColor' }}
+            />
+            <span>{icon.label}</span>
+          </MenuIcon>
         </NavLink>
       ))}
     </MenuBar>

--- a/frontend/src/components/BottomMenuBar/styles/BottomMenuBar.style.tsx
+++ b/frontend/src/components/BottomMenuBar/styles/BottomMenuBar.style.tsx
@@ -17,6 +17,7 @@ export const MenuIcon = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: 0.3rem;
   color: #333;
 
   span {

--- a/frontend/src/components/BottomMenuBar/styles/BottomMenuBar.style.tsx
+++ b/frontend/src/components/BottomMenuBar/styles/BottomMenuBar.style.tsx
@@ -1,4 +1,3 @@
-// BottomMenuBar.style.tsx
 import styled from 'styled-components'
 
 export const MenuBar = styled.div`
@@ -14,28 +13,18 @@ export const MenuBar = styled.div`
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
 `
 
-export const MenuIcon = styled.div<{ isActive: boolean }>`
+export const MenuIcon = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  color: ${({ isActive }) =>
-    isActive ? '#525FD4' : '#333'}; // Active color vs Inactive color
+  color: #333;
 
   span {
     margin-top: 4px;
     font-size: 12px;
   }
 
-  .active {
-    color: #007bff; // Define the active icon color
+  .active & {
+    color: #525fd4;
   }
 `
-
-// interface MenuIconProps {
-//   src: string // SVG URL
-//   alt: string
-// }
-// export const MenuIcon = styled.img<MenuIconProps>`
-//   width: 2rem;
-//   height: 2rem;
-// `

--- a/frontend/src/style/MobileStyle.ts
+++ b/frontend/src/style/MobileStyle.ts
@@ -6,6 +6,10 @@ export const MobileContainer = styled.div`
   margin-left: auto;
   margin-right: auto;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  height: 100vh;
+  height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
   overflow-y: auto;
 `


### PR DESCRIPTION
## #️⃣연관된 이슈

close #48 

## 💡 핵심적으로 구현된 사항
![image](https://github.com/user-attachments/assets/873623d7-4e20-41b9-9c6a-6ed81b8612a7)

- 다음의 경고 해결:  MenuIcon에 `isActive`를 직접 전달하지 않고, `.active` 클래스가 있는 경우 MenuIcon의 색상을 변경하도록 수정
- 아이폰의 safe-area 영역을 고려하도록 수정했지만 실제 모바일 화면에서 확인해야지 잘 되는지 알 수 있을 듯
  - html 소스에서 viewport의 content 속성에 `viewport-fit=cover` 넣어주기
  ```ts
  padding-top: env(safe-area-inset-top);
  padding-right: env(safe-area-inset-right);
  padding-bottom: env(safe-area-inset-bottom);
  padding-left: env(safe-area-inset-left);
  ```
  - 해당 부분 추가해주기

## ➕ 그 외에 추가적으로 구현된 사항

없음

## 🤔 테스트,검증 && 고민 사항

- height를 100vh로 설정하면 안된다는 이야기가 있어서, 100vh에서 위와 아래 영역 빼게 해보았는데 될 지 모르겠음..

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->