### PR TITLE
[Feature/#66/place detail] 장소 디테일 2차 구현

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,6 +24,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=7ca2799a454b4b58cf19c142092997cd"
+    ></script>
     <title>아이러닝</title>
   </head>
   <body>

--- a/frontend/src/api/calendar/postLike.ts
+++ b/frontend/src/api/calendar/postLike.ts
@@ -1,0 +1,19 @@
+import { AxiosResponse } from 'axios'
+
+import { aiLearningAxios } from '../axiosInstance'
+
+interface SuccessResponse {
+  message: string
+}
+
+export const postLike = async (
+  token: string,
+  contentid: number,
+): Promise<AxiosResponse<SuccessResponse> | null> => {
+  const response = await aiLearningAxios.post(
+    'calendar/like',
+    { contentid },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}

--- a/frontend/src/api/calendar/postPlaceLike.ts
+++ b/frontend/src/api/calendar/postPlaceLike.ts
@@ -1,0 +1,19 @@
+import { AxiosResponse } from 'axios'
+
+import { aiLearningAxios } from '../axiosInstance'
+
+interface SuccessResponse {
+  like: number
+}
+
+export const postPlaceLike = async (
+  token: string,
+  contentid: number,
+): Promise<AxiosResponse<SuccessResponse> | null> => {
+  const response = await aiLearningAxios.post(
+    'calendar/place-like',
+    { contentid },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}

--- a/frontend/src/api/profile/getLike.ts
+++ b/frontend/src/api/profile/getLike.ts
@@ -1,0 +1,14 @@
+import { aiLearningAxios } from '../axiosInstance'
+import { PlaceAllPreviewInfo } from '../calendar/getAllPlace'
+
+export const getLike = async (
+  token: string,
+): Promise<PlaceAllPreviewInfo[]> => {
+  const response = await aiLearningAxios.get<PlaceAllPreviewInfo[]>(
+    'profile/get-like',
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+  return response.data
+}

--- a/frontend/src/hooks/useLikeList.ts
+++ b/frontend/src/hooks/useLikeList.ts
@@ -1,0 +1,30 @@
+import { useQuery } from 'react-query'
+
+import { PlaceAllPreviewInfo } from '../api/calendar/getAllPlace'
+import { getLike } from '../api/profile/getLike'
+import authToken from '../stores/authToken'
+
+const useLikeList = () => {
+  const token = authToken.getAccessToken()
+
+  const { data, isLoading, isError, refetch } = useQuery<PlaceAllPreviewInfo[]>(
+    ['likeList', token],
+    async () => {
+      if (!token) return []
+      const response = await getLike(token)
+      return response || []
+    },
+    {
+      enabled: !!token,
+      staleTime: 1000 * 60 * 5,
+      cacheTime: 1000 * 60 * 10,
+      onError: error => {
+        console.error('Error fetching like list:', error)
+      },
+    },
+  )
+
+  return { likeList: data, isLoading, isError, refetch }
+}
+
+export default useLikeList

--- a/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
+++ b/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
@@ -80,7 +80,9 @@ const PlaceBoxItem: React.FC<PlaceBoxItemProps> = ({
 
   const handleClick = () => {
     if (!isEditing) {
-      navigate(`/place/${encodeURIComponent(item.contentid)}`)
+      navigate(
+        `/place/${encodeURIComponent(item.contenttypeid)}/${encodeURIComponent(item.contentid)}`,
+      )
     }
   }
 

--- a/frontend/src/pages/LoginPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LoginPage/components/LoginForm.tsx
@@ -1,8 +1,10 @@
+// src/components/LoginForm.tsx
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import SocialLogin from './SocialLogin'
 import { login } from '../../../api/auth/postLogin'
+import useLikeList from '../../../hooks/useLikeList'
 import { useUser } from '../../../hooks/useUser'
 import authToken from '../../../stores/authToken'
 import * as L from '../styles/Login.style'
@@ -13,11 +15,13 @@ const LoginForm = () => {
   const navigate = useNavigate()
 
   const { refetch: refetchUser } = useUser() // refetch 함수를 사용하여 로그인 후 유저 정보를 갱신
+  const { refetch: refetchLikeList } = useLikeList() // 좋아요 리스트 갱신
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setEmail(e.target.value)
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setPassword(e.target.value)
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
@@ -27,6 +31,7 @@ const LoginForm = () => {
       if (loginResult) {
         authToken.setAccessToken(loginResult.data.token)
         await refetchUser()
+        await refetchLikeList()
         navigate('/calendar')
       } else {
         console.error('login fail')

--- a/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
+++ b/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
@@ -38,6 +38,8 @@ const PlaceDetail = () => {
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
   const imageContainerRef = useRef<HTMLDivElement | null>(null)
   const [imageHeight, setImageHeight] = useState<number>(200)
+  const [homepage, setHomepage] = useState<string>('') // homepage 상태 추가
+  const [overview, setOverview] = useState<string>('') // overview 상태 추가
 
   useEffect(() => {
     const fetchPlaceDetail = async () => {
@@ -50,6 +52,28 @@ const PlaceDetail = () => {
     }
 
     fetchPlaceDetail()
+  }, [token, contentid])
+
+  useEffect(() => {
+    const fetchCommonPlaceInfo = async () => {
+      if (!token || !contentid) return
+
+      try {
+        const response = await fetch(
+          `https://apis.data.go.kr/B551011/KorService1/detailCommon1?serviceKey=I%2BMzNcsHcMWL7gORiWo%2BBaZ%2FPl8w4OpluiaN88eg5zIYnjtoQ0pxS6Vpy6OaHBaIf%2BrZf9%2FgjDcrtUBv%2BcuhCw%3D%3D&MobileOS=ETC&MobileOS=ETC&MobileApp=AILearning&_type=json&contentId=${contentid}&contentTypeId=12&defaultYN=Y&firstImageYN=N&areacodeYN=N&catcodeYN=N&addrinfoYN=N&mapinfoYN=N&overviewYN=Y&numOfRows=10&pageNo=1`,
+        )
+        const data = await response.json()
+        if (data.response.body.items.item[0]) {
+          const item = data.response.body.items.item[0]
+          setHomepage(item.homepage) // homepage 값 설정
+          setOverview(item.overview) // overview 값 설정
+        }
+      } catch (error) {
+        console.error('Failed to fetch place details:', error)
+      }
+    }
+
+    fetchCommonPlaceInfo()
   }, [token, contentid])
 
   useEffect(() => {
@@ -81,10 +105,9 @@ const PlaceDetail = () => {
   }
 
   const handleMapToggle = () => {
-    setShowMap(!showMap) // Toggle between map and image
+    setShowMap(!showMap)
   }
 
-  // Kakao Map API initialization
   useEffect(() => {
     // 추후 showMap && 추가!
     if (mapContainerRef.current && placeDetail) {
@@ -168,6 +191,7 @@ const PlaceDetail = () => {
         <L.ImageContainer
           ref={mapContainerRef}
           style={{
+            minHeight: '200px',
             height: `${imageHeight}px`,
             borderRadius: '8px',
             boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
@@ -177,6 +201,7 @@ const PlaceDetail = () => {
           <L.ImageContainer
             ref={mapContainerRef}
             style={{
+              minHeight: '200px',
               height: `${imageHeight}px`,
               borderRadius: '8px',
               boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
@@ -191,6 +216,17 @@ const PlaceDetail = () => {
               />
             </L.ImageContainer>
           )
+        )}
+        {homepage && (
+          <L.OverviewContainer>
+            <L.OverviewTitle>홈페이지</L.OverviewTitle>
+            <L.HomepageLink dangerouslySetInnerHTML={{ __html: homepage }} />
+          </L.OverviewContainer>
+        )}
+        {overview && (
+          <L.OverviewContainer>
+            <L.OverviewText>{overview}</L.OverviewText>
+          </L.OverviewContainer>
         )}
       </L.Container>
     </>

--- a/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
+++ b/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
@@ -5,6 +5,7 @@ import heartIcon from '@iconify-icons/tabler/heart-filled'
 import React, { useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 
+import PlaceMap from './components/PlaceMap'
 import * as L from './styles/PlaceDetail.style'
 import { postLike } from '../../api/calendar/postLike'
 // import { postTimelineDetail } from '../../api/calendar/postTimelineDetail'
@@ -32,7 +33,6 @@ const PlaceDetail = () => {
   const { likeList, refetch: refetchLikeList } = useLikeList()
   const [isLiked, setIsLiked] = useState<boolean>(false)
   const [showMap, setShowMap] = useState<boolean>(false)
-  const mapContainerRef = useRef<HTMLDivElement | null>(null)
   const imageContainerRef = useRef<HTMLDivElement | null>(null)
   const [imageHeight, setImageHeight] = useState<number>(200)
 
@@ -102,57 +102,6 @@ const PlaceDetail = () => {
     setShowMap(prevState => !prevState)
   }
 
-  // 지도 컴포넌트 분리
-  const MapComponent = () => {
-    useEffect(() => {
-      if (mapContainerRef.current && placeDetail) {
-        const { mapx, mapy } = placeDetail
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const kakao = (window as any).kakao
-
-        if (!kakao.maps) {
-          const script = document.createElement('script')
-          script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=YOUR_APP_KEY&autoload=false`
-          document.head.appendChild(script)
-
-          script.onload = () => {
-            kakao.maps.load(() => {
-              if (mapContainerRef.current) {
-                const container = mapContainerRef.current
-                const options = {
-                  center: new kakao.maps.LatLng(mapy, mapx),
-                  level: 3,
-                }
-                new kakao.maps.Map(container, options)
-              }
-            })
-          }
-        } else {
-          if (mapContainerRef.current) {
-            const container = mapContainerRef.current
-            const options = {
-              center: new kakao.maps.LatLng(mapy, mapx),
-              level: 3,
-            }
-            new kakao.maps.Map(container, options)
-          }
-        }
-      }
-    }, [placeDetail])
-
-    return (
-      <L.ImageContainer
-        ref={mapContainerRef}
-        style={{
-          minHeight: '200px',
-          height: `${imageHeight}px`,
-          borderRadius: '8px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-        }}
-      />
-    )
-  }
-
   const getContentTypeText = (contenttypeid: number) => {
     switch (contenttypeid) {
       case 12:
@@ -204,7 +153,11 @@ const PlaceDetail = () => {
         </L.SecondLineContainer>
 
         {showMap ? (
-          <MapComponent />
+          <PlaceMap
+            mapx={placeDetail?.mapx || 0}
+            mapy={placeDetail?.mapy || 0}
+            height={imageHeight}
+          />
         ) : (
           placeDetail?.firstimage && (
             <L.ImageContainer ref={imageContainerRef}>

--- a/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
+++ b/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
@@ -1,6 +1,5 @@
 import mapMarker from '@iconify/icons-majesticons/map-marker'
 import { Icon } from '@iconify/react'
-import mapOutline from '@iconify-icons/material-symbols/map-outline'
 import heartIcon from '@iconify-icons/tabler/heart-filled'
 import React, { useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
@@ -116,8 +115,17 @@ const PlaceDetail = () => {
     <>
       <BackButton />
       <L.MapIconContainer onClick={handleMapToggle}>
-        <Icon icon={mapOutline} width='28' height='28' />
+        {showMap ? (
+          <Icon icon='system-uicons:picture' width='28' height='28' />
+        ) : (
+          <Icon
+            icon='material-symbols-light:map-outline'
+            width='28'
+            height='28'
+          />
+        )}
       </L.MapIconContainer>
+
       <L.Container>
         <L.Title>
           <L.Text>{placeDetail?.title || ''}</L.Text>

--- a/frontend/src/pages/PlaceDetailPage/components/PlaceMap.tsx
+++ b/frontend/src/pages/PlaceDetailPage/components/PlaceMap.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef } from 'react'
+
+interface PlaceMapProps {
+  mapx: number
+  mapy: number
+  height: number
+}
+
+const PlaceMap: React.FC<PlaceMapProps> = ({ mapx, mapy, height }) => {
+  const mapContainerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (mapContainerRef.current) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const kakao = (window as any).kakao
+
+      // 지도 스크립트 로드 및 지도 생성
+      if (!kakao.maps) {
+        const script = document.createElement('script')
+        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=YOUR_APP_KEY&autoload=false`
+        document.head.appendChild(script)
+
+        script.onload = () => {
+          kakao.maps.load(() => {
+            const container = mapContainerRef.current
+            const options = {
+              center: new kakao.maps.LatLng(mapy, mapx),
+              level: 3,
+            }
+            new kakao.maps.Map(container, options)
+          })
+        }
+      } else {
+        const container = mapContainerRef.current
+        const options = {
+          center: new kakao.maps.LatLng(mapy, mapx),
+          level: 3,
+        }
+        new kakao.maps.Map(container, options)
+      }
+    }
+  }, [mapx, mapy])
+
+  return (
+    <div
+      ref={mapContainerRef}
+      style={{
+        minHeight: '200px',
+        height: `${height}px`,
+        borderRadius: '8px',
+        boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+      }}
+    />
+  )
+}
+
+export default PlaceMap

--- a/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
+++ b/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
@@ -3,12 +3,13 @@ import { styled } from 'styled-components'
 export const Container = styled.div`
   box-sizing: border-box;
   width: 100%;
-  height: calc(100vh - 5rem); /* BackButton 높이만큼 빼기 */
+  height: 100vh;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
   padding: 2rem;
-  padding-top: 5.5rem; /* BackButton 높이만큼 추가 */
+  padding-top: 5.5rem;
+  overflow-y: auto;
 `
 
 export const MapIconContainer = styled.div`
@@ -72,7 +73,6 @@ export const ImageContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 1rem;
 `
 
 export const PlaceImage = styled.img`
@@ -80,4 +80,31 @@ export const PlaceImage = styled.img`
   height: auto;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`
+
+export const OverviewContainer = styled.div`
+  padding: 1rem 0;
+`
+
+export const OverviewTitle = styled.h3`
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #333;
+`
+
+export const OverviewText = styled.p`
+  font-size: 0.9rem;
+  line-height: 1.4;
+`
+
+export const HomepageLink = styled.div`
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: #1a73e8;
+  word-break: break-word; /* 긴 URL을 잘 보이게 처리 */
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
 `

--- a/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
+++ b/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
@@ -6,9 +6,9 @@ export const Container = styled.div`
   height: calc(100vh - 5rem); /* BackButton 높이만큼 빼기 */
   display: flex;
   flex-direction: column;
-  gap: 1.6rem;
+  gap: 0.8rem;
   padding: 2rem;
-  padding-top: 6rem; /* BackButton 높이만큼 추가 */
+  padding-top: 5.5rem; /* BackButton 높이만큼 추가 */
 `
 
 export const MapIconContainer = styled.div`
@@ -24,13 +24,47 @@ export const MapIconContainer = styled.div`
 `
 
 export const Title = styled.div`
+  display: flex;
   line-height: 1rem;
-  margin-bottom: 0.5rem;
 `
 
 export const Text = styled.p`
   font-size: 1.3rem;
   font-weight: 700;
+`
+
+export const SecondLineContainer = styled.div`
+  justify-content: space-between;
+  display: flex;
+`
+
+export const SecondLineButton = styled.button`
+  height: 1.2rem;
+  padding: 0 1rem;
+  border: none;
+  border-radius: 1rem;
+  background-color: #3a3a3a;
+  color: white;
+  font-size: 0.5rem;
+  margin-left: 0.2rem;
+  cursor: pointer;
+`
+
+export const LikeContatiner = styled.div`
+  display: flex;
+  margin-left: 0.3rem;
+`
+
+export const SmText = styled.p`
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding-left: 0.1rem;
+`
+
+export const LocationText = styled.p`
+  font-size: 0.8rem;
+  line-height: 1.1rem;
+  margin-left: 0.1rem;
 `
 
 export const ImageContainer = styled.div`

--- a/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
+++ b/frontend/src/pages/PlaceDetailPage/styles/PlaceDetail.style.tsx
@@ -22,6 +22,8 @@ export const MapIconContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  z-index: 10;
+  cursor: pointer;
 `
 
 export const Title = styled.div`

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -45,7 +45,7 @@ const router = createBrowserRouter([
         element: <CalendarCycle />,
       },
       {
-        path: 'place/:contentid',
+        path: 'place/:contenttypeid/:contentid',
         element: <PlaceDetail />,
       },
       {


### PR DESCRIPTION
## #️⃣연관된 이슈

#66 

## 💡 핵심적으로 구현된 사항
![image](https://github.com/user-attachments/assets/b7f90bb4-6269-44c0-bb3b-5bc7ec82f35b)

 - contenttypeid/contentid 로 페이지 이동하게끔 변경

<p>
 <img src="https://github.com/user-attachments/assets/7af484f7-5ba6-460b-afb3-92d3889dcd13" width="40%" />
 <img src="https://github.com/user-attachments/assets/a2627a8f-9713-4c07-b001-d5283edffd20" width="40%" />
</p>

- 국문관광정보 공통정보조회 api를 받아온 contentid를 통해 요청해서 정보 받아서 반환
- mapx, mapy 정보값을 통해 카카오맵 연결해 해당 x,y 좌표 위치 띄우기
- 좋아요 반환, 좋아요 저장 및 취소 연결 (api 통신테스트 필요)

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적기 -->

## ➕ 그 외에 추가적으로 구현된 사항

- 로그인 진행 시 자동으로 해당 유저의 좋아요 목록 반환받아서 react-query 통해 저장하는 로직 추가

## 🤔 테스트,검증 && 고민 사항

contentid를 통해 공통정보조회를 프론트에서 진행한다면 굳이 기존에 넘겨받기로 한 대부분의 정보를 받지 않아도 될 거 같다고 판단!
 -> 필요한 값이 city와 좋아요 수인데, 각 장소별 좋아요 수 반환 api를 따로 만들고 기존 각 장소 세부 정보 반환 api는 쓰지 않는 쪽으로 생각하였음.
 -> 공통정보조회 반환 속도가 나쁘지 않다고 판단.
@Leehongseok-code @katekim512 @jeongmyunghee 

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->