### PR TITLE
[Test 💻] 카카오 로그인 로직 수정

### DIFF
--- a/frontend/src/api/auth/postKakaoCallback.ts
+++ b/frontend/src/api/auth/postKakaoCallback.ts
@@ -4,6 +4,7 @@ import { aiLearningAxios } from '../axiosInstance'
 
 interface CallbackResponse {
   userExists: boolean
+  token: string
 }
 
 export const kakaoCallback = async (

--- a/frontend/src/api/auth/postNewAccessToken.ts
+++ b/frontend/src/api/auth/postNewAccessToken.ts
@@ -3,14 +3,16 @@ import { AxiosResponse } from 'axios'
 import { aiLearningAxios } from '../axiosInstance'
 
 interface SuccessResponse {
-  accessToken: string
+  token: string
 }
 
 export const postNewAccessToken = async (
   accessToken: string,
+  newAccessToken: string,
 ): Promise<AxiosResponse<SuccessResponse> | null> => {
   const response = await aiLearningAxios.post('members/kakao-new-access', {
     accessToken,
+    newAccessToken,
   })
   return response.data
 }

--- a/frontend/src/pages/LoginPage/components/KakaoRedirectHandle.tsx
+++ b/frontend/src/pages/LoginPage/components/KakaoRedirectHandle.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { kakaoCallback } from '../../../api/auth/postKakaoCallback'
 import { postNewAccessToken } from '../../../api/auth/postNewAccessToken'
 import { postRefreshAccessToken } from '../../../api/auth/postRefreshAccessToken'
+import authKakaoToken from '../../../stores/authKakaoToken'
 import authToken from '../../../stores/authToken'
 import { isAxios401Error } from '../../../utils/isAxios401Error'
 
@@ -35,7 +36,7 @@ const KakaoRedirectHandle = () => {
         const refreshToken = res.data.refresh_token
         kakao.Auth.setAccessToken(accessToken)
 
-        authToken.setTokens(accessToken, refreshToken)
+        authKakaoToken.setTokens(accessToken, refreshToken)
         getUserInfo(accessToken, refreshToken)
       })
       .catch(error => {
@@ -54,6 +55,7 @@ const KakaoRedirectHandle = () => {
         const callbackResponse = await kakaoCallback(accessToken)
         if (callbackResponse?.data.userExists) {
           navigate('/calendar')
+          authToken.setToken(callbackResponse.data.token)
         } else {
           navigate('/register', { state: { accessToken, email } })
         }
@@ -65,8 +67,8 @@ const KakaoRedirectHandle = () => {
         if (isAxios401Error(error)) {
           const newAccessToken = await postRefreshAccessToken(refreshToken)
           if (newAccessToken) {
-            authToken.setAccessToken(newAccessToken)
-            await postNewAccessToken(newAccessToken)
+            authKakaoToken.setAccessToken(newAccessToken)
+            await postNewAccessToken(accessToken, newAccessToken)
 
             // 재발급 받은 액세스 토큰으로 사용자 정보 다시 요청
             kakao.Auth.setAccessToken(newAccessToken)

--- a/frontend/src/pages/LoginPage/components/KakaoRedirectHandle.tsx
+++ b/frontend/src/pages/LoginPage/components/KakaoRedirectHandle.tsx
@@ -68,11 +68,20 @@ const KakaoRedirectHandle = () => {
           const newAccessToken = await postRefreshAccessToken(refreshToken)
           if (newAccessToken) {
             authKakaoToken.setAccessToken(newAccessToken)
-            await postNewAccessToken(accessToken, newAccessToken)
+            const successResponse = await postNewAccessToken(
+              accessToken,
+              newAccessToken,
+            )
 
-            // 재발급 받은 액세스 토큰으로 사용자 정보 다시 요청
-            kakao.Auth.setAccessToken(newAccessToken)
-            getUserInfo(newAccessToken, refreshToken)
+            if (successResponse && successResponse.data) {
+              authToken.setToken(successResponse.data.token)
+
+              // 재발급 받은 액세스 토큰으로 사용자 정보 다시 요청
+              kakao.Auth.setAccessToken(newAccessToken)
+              getUserInfo(newAccessToken, refreshToken)
+            } else {
+              console.error('새로운 액세스 토큰 백엔드 전달 실패')
+            }
           } else {
             console.error('액세스 토큰 재발급 실패')
           }

--- a/frontend/src/pages/LoginPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LoginPage/components/LoginForm.tsx
@@ -23,7 +23,7 @@ const LoginForm = () => {
       const loginResult = await login(email, password)
 
       if (loginResult) {
-        authToken.setAccessToken(loginResult.data.token)
+        authToken.setToken(loginResult.data.token)
         navigate('/calendar')
       } else {
         console.error('login fail')

--- a/frontend/src/stores/authKakaoToken.ts
+++ b/frontend/src/stores/authKakaoToken.ts
@@ -1,0 +1,75 @@
+class AuthKakaoToken {
+  private accessToken: string
+  private refreshToken: string
+  private readonly TOKEN_KEY: string = 'kakaoTokens' // 저장할 키 값
+
+  constructor() {
+    // 초기화 시 localStorage에서 토큰 정보를 가져옵니다.
+    const storedTokens = localStorage.getItem(this.TOKEN_KEY)
+    if (storedTokens) {
+      const parsedTokens = JSON.parse(storedTokens)
+      this.accessToken = parsedTokens.accessToken || ''
+      this.refreshToken = parsedTokens.refreshToken || ''
+    } else {
+      this.accessToken = ''
+      this.refreshToken = ''
+    }
+  }
+
+  // 새로운 accessToken과 refreshToken을 설정하고 저장합니다.
+  setTokens(newAccessToken: string, newRefreshToken: string) {
+    try {
+      const tokenData = {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+      }
+      localStorage.setItem(this.TOKEN_KEY, JSON.stringify(tokenData))
+      this.accessToken = newAccessToken
+      this.refreshToken = newRefreshToken
+    } catch (e) {
+      this.accessToken = ''
+      this.refreshToken = ''
+    }
+  }
+
+  // accessToken을 가져오는 메서드
+  getAccessToken() {
+    return this.accessToken
+  }
+
+  // refreshToken을 가져오는 메서드
+  getRefreshToken() {
+    return this.refreshToken
+  }
+
+  // 특정 토큰만 설정하는 경우
+  setAccessToken(newAccessToken: string) {
+    this.accessToken = newAccessToken
+    this.updateLocalStorage()
+  }
+
+  setRefreshToken(newRefreshToken: string) {
+    this.refreshToken = newRefreshToken
+    this.updateLocalStorage()
+  }
+
+  // 로컬스토리지에 저장된 토큰 정보를 업데이트합니다.
+  private updateLocalStorage() {
+    const tokenData = {
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken,
+    }
+    localStorage.setItem(this.TOKEN_KEY, JSON.stringify(tokenData))
+  }
+
+  // 토큰 정보를 제거합니다.
+  removeTokens() {
+    localStorage.removeItem(this.TOKEN_KEY)
+    this.accessToken = ''
+    this.refreshToken = ''
+  }
+}
+
+const authKakaoToken = new AuthKakaoToken()
+
+export default authKakaoToken

--- a/frontend/src/stores/authToken.ts
+++ b/frontend/src/stores/authToken.ts
@@ -1,72 +1,41 @@
 class AuthToken {
-  private accessToken: string
-  private refreshToken: string
-  private readonly TOKEN_KEY: string = 'authTokens' // 저장할 키 값
+  private token: string
+  private readonly TOKEN_KEY: string = 'authToken' // 저장할 키 값
 
   constructor() {
     // 초기화 시 localStorage에서 토큰 정보를 가져옵니다.
-    const storedTokens = localStorage.getItem(this.TOKEN_KEY)
-    if (storedTokens) {
-      const parsedTokens = JSON.parse(storedTokens)
-      this.accessToken = parsedTokens.accessToken || ''
-      this.refreshToken = parsedTokens.refreshToken || ''
+    const storedToken = localStorage.getItem(this.TOKEN_KEY)
+    if (storedToken) {
+      this.token = storedToken || ''
     } else {
-      this.accessToken = ''
-      this.refreshToken = ''
+      this.token = ''
     }
   }
 
-  // 새로운 accessToken과 refreshToken을 설정하고 저장합니다.
-  setTokens(newAccessToken: string, newRefreshToken: string) {
+  // 새로운 accessToken을 설정하고 저장합니다.
+  setToken(newAccessToken: string) {
     try {
-      const tokenData = {
-        accessToken: newAccessToken,
-        refreshToken: newRefreshToken,
-      }
-      localStorage.setItem(this.TOKEN_KEY, JSON.stringify(tokenData))
-      this.accessToken = newAccessToken
-      this.refreshToken = newRefreshToken
+      localStorage.setItem(this.TOKEN_KEY, newAccessToken)
+      this.token = newAccessToken
     } catch (e) {
-      this.accessToken = ''
-      this.refreshToken = ''
+      this.token = ''
     }
   }
 
   // accessToken을 가져오는 메서드
   getAccessToken() {
-    return this.accessToken
+    return this.token
   }
 
-  // refreshToken을 가져오는 메서드
-  getRefreshToken() {
-    return this.refreshToken
-  }
-
-  // 특정 토큰만 설정하는 경우
-  setAccessToken(newAccessToken: string) {
-    this.accessToken = newAccessToken
-    this.updateLocalStorage()
-  }
-
-  setRefreshToken(newRefreshToken: string) {
-    this.refreshToken = newRefreshToken
-    this.updateLocalStorage()
-  }
-
-  // 로컬스토리지에 저장된 토큰 정보를 업데이트합니다.
+  // accessToken을 로컬스토리지에 저장된 정보로 업데이트합니다.
   private updateLocalStorage() {
-    const tokenData = {
-      accessToken: this.accessToken,
-      refreshToken: this.refreshToken,
-    }
-    localStorage.setItem(this.TOKEN_KEY, JSON.stringify(tokenData))
+    localStorage.setItem(this.TOKEN_KEY, this.token)
   }
 
   // 토큰 정보를 제거합니다.
-  removeTokens() {
+  removeToken() {
     localStorage.removeItem(this.TOKEN_KEY)
-    this.accessToken = ''
-    this.refreshToken = ''
+    this.token = ''
   }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #92 

## 💡 핵심적으로 구현된 사항

![image](https://github.com/user-attachments/assets/91748576-2134-41a9-8714-1c09cecc30ef)

- 카카오 accessToken, refreshToken을 별도로 authKakaoToken.ts에 저장하도록 분리시킴

## ➕ 그 외에 추가적으로 구현된 사항

없음

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->