### PR TITLE
[Fix ✏️] 장소추가 후 캘린더 돌아올 때 해당 날짜 Drawer 열리도록 수정

### DIFF
--- a/frontend/src/pages/CalendarPage/Calendar.tsx
+++ b/frontend/src/pages/CalendarPage/Calendar.tsx
@@ -12,9 +12,8 @@ import useVisitedList from '../../hooks/useVisitedList'
 const Calendar = () => {
   const navigate = useNavigate()
   const location = useLocation()
-
-  // selectedDate는 AddPlace에서 전달된 값
   const selectedDate = location.state?.selectedDate || null
+
   const { refetch: refetchUser } = useUser()
   const { refetch: refetchLikeList } = useLikeList()
   const { refetch: refetchVisitedList } = useVisitedList()
@@ -33,19 +32,24 @@ const Calendar = () => {
         year: Number(year),
         month: Number(month),
       })
+    } else {
+      // selectedDate가 없을 때만 현재 날짜로 설정
+      setCurrentDate({
+        year: today.getFullYear(),
+        month: today.getMonth() + 1,
+      })
     }
   }, [selectedDate])
-
-  useEffect(() => {
-    saveInfos()
-    setCurrentDate({ year: today.getFullYear(), month: today.getMonth() + 1 })
-  }, [])
 
   const saveInfos = async () => {
     await refetchUser()
     await refetchLikeList()
     await refetchVisitedList()
   }
+
+  useEffect(() => {
+    saveInfos()
+  }, [])
 
   const handleAIScheduleButton = () => {
     navigate('/ai-schedule-step1')

--- a/frontend/src/pages/CalendarPage/Calendar.tsx
+++ b/frontend/src/pages/CalendarPage/Calendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { FaWandMagicSparkles } from 'react-icons/fa6'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useSwipeable } from 'react-swipeable'
 
 import MainCalendar from './components/MainCalendar'
@@ -11,15 +11,30 @@ import useVisitedList from '../../hooks/useVisitedList'
 
 const Calendar = () => {
   const navigate = useNavigate()
-  const { refetch: refetchUser } = useUser() // refetch 함수를 사용하여 로그인 후 유저 정보를 갱신
-  const { refetch: refetchLikeList } = useLikeList() // 좋아요 리스트 갱신
-  const { refetch: refetchVisitedList } = useVisitedList() // 방문장소 리스트 갱신
+  const location = useLocation()
+
+  // selectedDate는 AddPlace에서 전달된 값
+  const selectedDate = location.state?.selectedDate || null
+  const { refetch: refetchUser } = useUser()
+  const { refetch: refetchLikeList } = useLikeList()
+  const { refetch: refetchVisitedList } = useVisitedList()
 
   const today = new Date()
   const [currentDate, setCurrentDate] = useState({
     year: today.getFullYear(),
     month: today.getMonth() + 1,
   })
+
+  // selectedDate가 존재하면 그 날짜의 Drawer를 열기 위한 로직
+  useEffect(() => {
+    if (selectedDate) {
+      const [year, month] = selectedDate.split('-')
+      setCurrentDate({
+        year: Number(year),
+        month: Number(month),
+      })
+    }
+  }, [selectedDate])
 
   useEffect(() => {
     saveInfos()
@@ -85,7 +100,6 @@ const Calendar = () => {
 
   const handleSwipeRight = () => {
     if (currentDate.year === 2024 && currentDate.month === 1) {
-      // 2024년 1월 이전으로 못 넘어가게 막음
       return
     }
 
@@ -128,7 +142,11 @@ const Calendar = () => {
             &nbsp;&nbsp;AI 교육여행
           </L.AIScheduleButton>
         </L.HeaderSection>
-        <MainCalendar year={currentDate.year} month={currentDate.month} />
+        <MainCalendar
+          year={currentDate.year}
+          month={currentDate.month}
+          selectedDate={selectedDate}
+        />
       </div>
     </>
   )

--- a/frontend/src/pages/CalendarPage/components/AddPlace.tsx
+++ b/frontend/src/pages/CalendarPage/components/AddPlace.tsx
@@ -14,7 +14,6 @@ import { getCityAndSigunguName } from '../../../style/CityMapper2'
 import PlaceItem from '../../RecommendPage/components/PlaceItem'
 import * as L from '../styles/AddPlace.style'
 import { NoPlaceContainer } from '../styles/NoPlace.style'
-// const dummyImage = '/img/default_pic.png'
 
 interface RecommendPlace {
   contentid: number
@@ -33,113 +32,6 @@ interface OpenAPIPlace {
   title: string // OpenAPI의 장소 이름 필드
   firstimage?: string
 }
-
-// const dummyData: RecommendPlace[] = [
-//   {
-//     contentid: 1,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 2,
-//     place: '불국사',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 2,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 2,
-//     place: '석굴암',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 3,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 2,
-//     place: '동궁과 월지',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 4,
-//     contenttypeid: 14,
-//     areacode: 35,
-//     sigungucode: 2,
-//     place: '경주 대릉원',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 5,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 3,
-//     place: '첨성대',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 6,
-//     contenttypeid: 15,
-//     areacode: 35,
-//     sigungucode: 4,
-//     place: '포석정',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 7,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 5,
-//     place: '경주 남산',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 8,
-//     contenttypeid: 16,
-//     areacode: 35,
-//     sigungucode: 6,
-//     place: '문무대왕릉',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 9,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 7,
-//     place: '경주 오릉',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 10,
-//     contenttypeid: 14,
-//     areacode: 35,
-//     sigungucode: 8,
-//     place: '경주 국립공원',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 11,
-//     contenttypeid: 13,
-//     areacode: 35,
-//     sigungucode: 9,
-//     place: '경주 월정교',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 12,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 10,
-//     place: '경주 황리단길',
-//     firstimage: dummyImage,
-//   },
-//   {
-//     contentid: 13,
-//     contenttypeid: 12,
-//     areacode: 35,
-//     sigungucode: 11,
-//     place: '경주 보문단지',
-//     firstimage: dummyImage,
-//   },
-// ]
 
 const AddPlace: React.FC = () => {
   const token = authToken.getAccessToken()
@@ -174,7 +66,6 @@ const AddPlace: React.FC = () => {
     }
   }
 
-  //-----API 연결----
   useEffect(() => {
     if (isAllPlacesLoading) {
       setIsLoading(true)
@@ -203,11 +94,6 @@ const AddPlace: React.FC = () => {
     }
   }
 
-  // 더미 데이터 불러오기
-  // useEffect(() => {
-  //   setRecommendedPlaces(dummyData)
-  // }, [date, token])
-
   const handleSearchInput = (input: string) => {
     setSearchInput(input)
   }
@@ -233,7 +119,11 @@ const AddPlace: React.FC = () => {
     try {
       const response = await postAddPlace(token, contentid, date)
       if (response) {
-        console.log('Place added successfully:', response.data.message)
+        navigate('/calendar', {
+          state: {
+            selectedDate: date, // date는 추가된 날짜
+          },
+        })
       } else {
         console.error('Failed to add place.')
       }

--- a/frontend/src/pages/CalendarPage/components/MainCalendar.tsx
+++ b/frontend/src/pages/CalendarPage/components/MainCalendar.tsx
@@ -12,6 +12,7 @@ import * as L from '../styles/Calendar.style'
 interface MainCalendarProps {
   year: number
   month: number
+  selectedDate?: string
 }
 
 interface Holiday {
@@ -19,7 +20,11 @@ interface Holiday {
   name: string
 }
 
-const MainCalendar: React.FC<MainCalendarProps> = ({ year, month }) => {
+const MainCalendar: React.FC<MainCalendarProps> = ({
+  year,
+  month,
+  selectedDate,
+}) => {
   const token = authToken.getAccessToken()
   const today = new Date()
 
@@ -35,8 +40,8 @@ const MainCalendar: React.FC<MainCalendarProps> = ({ year, month }) => {
   const [daySectionHeight, setDaySectionHeight] = useState<number>(0)
   const [schedule, setSchedule] = useState<CalendarSchedule[]>([])
   const [holidays, setHolidays] = useState<Holiday[]>([])
-  const [selectedDay, setSelectedDay] = useState<string>('')
-  const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
+  const [selectedDay, setSelectedDay] = useState<string>(selectedDate || '')
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(!!selectedDate)
 
   const fetchHolidayInfo = async () => {
     try {
@@ -270,6 +275,7 @@ const MainCalendar: React.FC<MainCalendarProps> = ({ year, month }) => {
 MainCalendar.propTypes = {
   year: PropTypes.number.isRequired,
   month: PropTypes.number.isRequired,
+  selectedDate: PropTypes.string,
 }
 
 export default MainCalendar

--- a/frontend/src/pages/DateSelectedPage/components/PlaceAddBanner.tsx
+++ b/frontend/src/pages/DateSelectedPage/components/PlaceAddBanner.tsx
@@ -31,7 +31,11 @@ const PlaceAddBanner: React.FC<PlaceAddBannerProps> = ({
       selectedDay,
     )
     if (successResponse) {
-      navigate('/calendar')
+      navigate('/calendar', {
+        state: {
+          selectedDate: selectedDay, // date는 추가된 날짜
+        },
+      })
     }
   }
 

--- a/frontend/src/pages/DateSelectedPage/styles/PlaceAddBanner.style.tsx
+++ b/frontend/src/pages/DateSelectedPage/styles/PlaceAddBanner.style.tsx
@@ -36,6 +36,7 @@ export const SelectedButton = styled.button`
   border-radius: 1.5rem;
   background-color: #525fd4;
   color: white;
+  white-space: nowrap;
   font-size: 0.9rem;
   font-weight: 600;
 `


### PR DESCRIPTION
## #️⃣연관된 이슈

close #123 

## 💡 핵심적으로 구현된 사항

<img src="https://github.com/user-attachments/assets/a96ba350-9535-4d39-a1c2-30d07d870e0d" width="190" />

- 다음과 같이 장소 추가를 완료하면 추가한 날짜의 Drawer이 활성화된 상태로 캘린더 페이지가 나타나도록 로직 수정 (state에 date 정보 담아서 Calendar.tsx에 전달)

## ➕ 그 외에 추가적으로 구현된 사항

PlaceAddBanner에서 완료 버튼 한 줄 고정 `nowrap` 적용

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->