### PR TITLE
[Feat 💡] chatgpt api 활용해 교외체험학습계획 결과 넣어주기

### DIFF
--- a/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
+++ b/frontend/src/pages/PlaceDetailPage/PlaceDetail.tsx
@@ -13,6 +13,7 @@ import ContentType15 from './components/ContentType/ContentType15'
 import MiddleMenuBar from './components/MiddleMenuBar'
 import PlaceMap from './components/PlaceMap'
 import RestaurantList from './components/RestaurantList'
+import StudyPlan from './components/StudyPlan/StudyPlan'
 import * as L from './styles/PlaceDetail.style'
 import { postAddVisited } from '../../api/calendar/postAddVisited'
 import { postLike } from '../../api/calendar/postLike'
@@ -294,6 +295,7 @@ const PlaceDetail = () => {
           )}
           {placeDetail && (
             <>
+              <StudyPlan title={placeDetail.title} />
               <AccomodationList
                 areacode={placeDetail.areacode!}
                 sigungucode={placeDetail.sigungucode!}

--- a/frontend/src/pages/PlaceDetailPage/components/StudyPlan/ChatGPT.ts
+++ b/frontend/src/pages/PlaceDetailPage/components/StudyPlan/ChatGPT.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+
+export const fetchPlacePlan = async (title: string, age: number) => {
+  const prompt = `대한민국의 장소인 ${title}에 대해 파악한 후, ${title}에 대한 교외체험학습계획을 역사적 관점에서 ${age}살에게 적합한 난이도와 내용으로 작성해 주세요. 활동 내용에 대해서만 '- ~~ 하기' 이 형식으로 3개 정도로 작성해주세요!`
+
+  const response = await axios.post(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+      max_tokens: 1000,
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
+      },
+    },
+  )
+
+  return response.data.choices[0].message.content
+}

--- a/frontend/src/pages/PlaceDetailPage/components/StudyPlan/StudyPlan.tsx
+++ b/frontend/src/pages/PlaceDetailPage/components/StudyPlan/StudyPlan.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react'
+
+import { fetchPlacePlan } from './ChatGPT'
+import { useUser } from '../../../../hooks/useUser'
+import * as L from '../../styles/PlaceDetail.style'
+
+interface Props {
+  title: string
+}
+
+const StudyPlan: React.FC<Props> = ({ title }) => {
+  const { data: userInfo } = useUser()
+  const [plan, setPlan] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const calculateAge = (birth: number) => {
+    const currentYear = new Date().getFullYear()
+    return currentYear - birth // 나이 계산
+  }
+
+  useEffect(() => {
+    const getPlan = async () => {
+      if (userInfo?.birth) {
+        setLoading(true)
+        const age = calculateAge(userInfo.birth)
+        try {
+          const placePlan = await fetchPlacePlan(title, age)
+          setPlan(placePlan)
+        } catch (error) {
+          console.error('Failed to fetch learning plan:', error)
+        } finally {
+          setLoading(false)
+        }
+      }
+    }
+
+    getPlan()
+  }, [title, userInfo?.birth])
+
+  return (
+    <>
+      <L.OverviewTitle>교외체험학습계획</L.OverviewTitle>
+      {loading ? (
+        <L.OverviewText>로딩 중...</L.OverviewText>
+      ) : (
+        <L.OverviewText>{plan || '계획이 없습니다.'}</L.OverviewText>
+      )}
+    </>
+  )
+}
+
+export default StudyPlan


### PR DESCRIPTION
## #️⃣연관된 이슈

close #127

## 💡 핵심적으로 구현된 사항

<p>
 <img src="https://github.com/user-attachments/assets/dcab7986-922a-47df-bb64-66fd0146daf3" width="40%" />
 <img src="https://github.com/user-attachments/assets/75a44f6a-b7d4-4e25-abd6-96f2ef002f70" width="40%" />
</p>

(순서대로 공주 공산성, 강화 고인돌 유적에 대한 체험학습계획 결과 반환)
- chatgpt api 활용해 교외체험학습계획 결과 넣어주기

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적기 -->

## ➕ 그 외에 추가적으로 구현된 사항

없음

## 🤔 테스트,검증 && 고민 사항

- 상세 장소 페이지 UI 개선

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->