### PR TITLE
[Fix/#144/register] 회원가입 로직 수정

### DIFF
--- a/frontend/src/pages/RegisterPage/components/RegisterForm.tsx
+++ b/frontend/src/pages/RegisterPage/components/RegisterForm.tsx
@@ -58,17 +58,36 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
 
   const [alertMessage, setAlertMessage] = useState<string>('') // 알림창 메시지 상태
   const [showAlert, setShowAlert] = useState<boolean>(false) // 알림창 표시 여부 상태
+  const [isChecked, setIsChecked] = useState({
+    emailChecked: !!accessToken, // accessToken이 있으면 이미 확인된 상태로 간주
+    nicknameChecked: false,
+  })
 
+  // 이메일 변경 시 중복확인 무효화
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setSignupForm({ ...signupForm, [name]: value })
+
+    if (name === 'email') {
+      setIsValid(prev => ({ ...prev, email: false }))
+      setIsChecked(prev => ({ ...prev, emailChecked: false }))
+      setValidMessage(prev => ({
+        ...prev,
+        emailMessage: '',
+      }))
+    }
+
+    if (name === 'nickname') {
+      setIsValid(prev => ({ ...prev, nickname: false }))
+      setIsChecked(prev => ({ ...prev, nicknameChecked: false }))
+      setValidMessage(prev => ({
+        ...prev,
+        nicknameMessage: '',
+      }))
+    }
   }
 
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { name, value } = e.target
-    setSignupForm({ ...signupForm, [name]: Number(value) })
-  }
-
+  // 이메일 중복확인 버튼 클릭 시
   const handleCheckEmail = async () => {
     const emailResult = await checkEmail(signupForm.email)
     if (emailResult?.data.isExist === true) {
@@ -90,8 +109,11 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
       }))
       setIsValid({ ...isValid, email: false })
     }
+
+    setIsChecked(prev => ({ ...prev, emailChecked: true })) // 중복확인 완료로 설정
   }
 
+  // 닉네임 중복확인 버튼 클릭 시
   const handleCheckNickname = async () => {
     const nicknameResult = await checkNickname(signupForm.nickname)
     if (nicknameResult?.data.isExist === true) {
@@ -113,6 +135,13 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
       }))
       setIsValid({ ...isValid, nickname: false })
     }
+
+    setIsChecked(prev => ({ ...prev, nicknameChecked: true })) // 중복확인 완료로 설정
+  }
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target
+    setSignupForm({ ...signupForm, [name]: Number(value) })
   }
 
   // 비밀번호 유효성 검사
@@ -198,7 +227,7 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
       return
     }
     if (!isValid.password) {
-      setAlertMessage('비밀번호가 유효하지 않습니다.')
+      setAlertMessage('비밀번호를 다시 한 번 확인해주세요.')
       setShowAlert(true)
       return
     }
@@ -257,7 +286,7 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
               중복확인
             </L.Button>
           )}
-          <L.ValidationMessage error={!isValid.email}>
+          <L.ValidationMessage error={!isValid.email && isChecked.emailChecked}>
             {validMessage.emailMessage}
           </L.ValidationMessage>
         </L.InputWrapper>
@@ -276,7 +305,9 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
           <L.Button type='button' onClick={handleCheckNickname}>
             중복확인
           </L.Button>
-          <L.ValidationMessage error={!isValid.nickname}>
+          <L.ValidationMessage
+            error={!isValid.nickname && isChecked.nicknameChecked}
+          >
             {validMessage.nicknameMessage}
           </L.ValidationMessage>
         </L.InputWrapper>

--- a/frontend/src/pages/RegisterPage/components/RegisterForm.tsx
+++ b/frontend/src/pages/RegisterPage/components/RegisterForm.tsx
@@ -1,23 +1,22 @@
 import { useEffect, useState } from 'react'
-// import { HiOutlineExclamationCircle } from 'react-icons/hi'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { checkEmail } from '../../../api/auth/postCheckEmail'
 import { checkNickname } from '../../../api/auth/postCheckNickname'
+import { login } from '../../../api/auth/postLogin'
 import { register } from '../../../api/auth/postRegister'
 import {
   getAreaNames,
   getSigunguByAreacode,
   Sigungu,
 } from '../../../datas/RegisterCityMapper'
+import authToken from '../../../stores/authToken'
 import * as L from '../styles/Register.style'
 
 const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
   const navigate = useNavigate()
   const location = useLocation()
   const emailFromKakao = location.state?.email || ''
-  //   const [openModal, setOpenModal] = useState(false)
-  //   const [openFailModal, setOpenFailModal] = useState(false)
 
   const [signupForm, setSignupForm] = useState({
     email: accessToken ? emailFromKakao : '',
@@ -222,24 +221,25 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
 
       console.log(signupForm.areacode)
 
-      if (registerResult) {
-        // setOpenModal(true)
+      if (registerResult && emailFromKakao) {
+        const successResponse = await login(
+          signupForm.email,
+          signupForm.password,
+        )
+        if (successResponse) {
+          authToken.setToken(successResponse.data.token)
+          navigate('/calendar')
+        }
+      } else if (registerResult) {
         navigate('/login')
       } else {
-        // setOpenFailModal(false)
         console.error('register fail')
       }
     } else {
-      //   setOpenFailModal(false)
       console.error('register fail')
       return
     }
   }
-
-  //   const handleSuccessPopUp = () => {
-  //     setOpenModal(false)
-  //     if (!openFailModal) navigate('/login')
-  //   }
 
   return (
     <L.Form onSubmit={handleSubmit}>
@@ -365,29 +365,10 @@ const RegisterForm = ({ accessToken }: { accessToken?: string }) => {
       </L.InputWrapper>
       <br />
       <L.SubmitButton type='submit'>회원가입 완료하기</L.SubmitButton>
-      {/* <L.TextCenter>
+      <L.TextCenter>
         이미 회원가입을 하셨나요?&nbsp;&nbsp;&nbsp;
-        <L.Link href="/login">로그인하기</L.Link>
-      </L.TextCenter> */}
-
-      {/* <L.ModalOverlay className={`${openModal ? 'block' : 'hidden'}`} />
-      <L.ModalWrapper className={`${openModal ? 'flex' : 'hidden'}`}>
-        <L.ModalContent>
-          <L.ModalBody>
-            <L.ModalIcon>
-              <HiOutlineExclamationCircle />
-            </L.ModalIcon>
-            <L.ModalText>
-              {openFailModal
-                ? '회원가입에 실패했습니다'
-                : '아이러닝의 회원이 되신 걸 환영합니다!'}
-            </L.ModalText>
-            <div className="flex justify-center gap-4">
-              <L.Button onClick={handleSuccessPopUp}>확인</L.Button>
-            </div>
-          </L.ModalBody>
-        </L.ModalContent>
-      </L.ModalWrapper> */}
+        <L.Link href='/login'>로그인하기</L.Link>
+      </L.TextCenter>
     </L.Form>
   )
 }

--- a/frontend/src/pages/RegisterPage/styles/Register.style.tsx
+++ b/frontend/src/pages/RegisterPage/styles/Register.style.tsx
@@ -9,6 +9,7 @@ export const Container = styled.div`
   gap: 1.6rem;
   align-items: center;
   padding: 1.5rem;
+  overflow-y: auto;
 `
 
 export const Title = styled.h1`
@@ -18,7 +19,6 @@ export const Title = styled.h1`
   text-align: center;
   padding: 1rem;
   border-bottom: 1px solid #dcdcdc;
-  margin-bottom: 1rem;
 `
 
 export const Form = styled.form`
@@ -122,7 +122,7 @@ export const SubmitButton = styled.button`
 `
 
 export const TextCenter = styled.p`
-  margin-top: 2.5rem;
+  margin-top: 1.2rem;
   text-align: center;
   font-size: 0.875rem;
   color: #6b7280;
@@ -138,7 +138,7 @@ export const Link = styled.a`
 
 export const ModalOverlay = styled.div`
   position: fixed;
-  top: 20px;
+  top: 0;
   left: 0;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #144 

## 💡 핵심적으로 구현된 사항

<p>
 <img src="https://github.com/user-attachments/assets/53812f0b-e9bb-4177-ab69-734e7fda3347" width="20%" />
 <img src="https://github.com/user-attachments/assets/615d18a0-fbde-4f0c-a541-adec7fc0eebe" width="20%" />
 <img src="https://github.com/user-attachments/assets/ed3f4f68-6f1e-4734-bd2a-2528b5d5e55d" width="20%" />
</p>

- 회원가입 버튼 눌렀을 때 잘못된 사항에 대해 팝업 띄워주기
- 카카오 로그인으로 회원가입 시 캘린더 화면으로 이동하게끔 (배포 테스트 필요)
- 회원가입 성공, 실패 여부에 따른 팝업 연결

## ➕ 그 외에 추가적으로 구현된 사항

- 회원가입이 아이폰12 환경말고 갤럭시에서 짤려서 급하게 overflow 적용시켜주긴 했음 (추후 수정 필요)

## 🤔 테스트,검증 && 고민 사항

- password만 유효성 검사 로직에서 잘못된 건 안보이는데 계속 false만 찍혀서 별도의 boolean으로 빼서 비교하도록 했음..

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->