### PR TITLE
[Fix/#145/date drawer] 캘린더 Drawer 관련 이슈 해결

### DIFF
--- a/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
+++ b/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
@@ -98,7 +98,7 @@ const PlaceBoxItem: React.FC<PlaceBoxItemProps> = ({
     <>
       <L.NumberCircle>{index + 1}</L.NumberCircle>
       {index < totalItems - 1 && (
-        <L.DistancePlaceholder>{distance[index]}m</L.DistancePlaceholder>
+        <L.DistancePlaceholder>{distance[index]}</L.DistancePlaceholder>
       )}
       <L.PlaceBoxContainer
         isSliding={!isEditing && isSliding === index}

--- a/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
+++ b/frontend/src/pages/CalendarPage/components/PlaceBoxItem.tsx
@@ -132,7 +132,10 @@ const PlaceBoxItem: React.FC<PlaceBoxItemProps> = ({
             <L.PlaceBoxPic alt='placePreview' src={item.firstimage} />
             <L.DeleteIcon
               isVisible={isSliding === index}
-              onClick={() => onDelete(index)}
+              onClick={e => {
+                e.stopPropagation()
+                onDelete(index)
+              }}
             >
               삭제
             </L.DeleteIcon>

--- a/frontend/src/pages/CalendarPage/components/TodayMemo.tsx
+++ b/frontend/src/pages/CalendarPage/components/TodayMemo.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import * as L from '../styles/TodayMemo.style'
+
+interface InfoBannerProps {
+  text: string
+}
+
+const TodayMemo: React.FC<InfoBannerProps> = ({ text }) => {
+  return (
+    <L.BannerContainer>
+      <L.BannerTitle>오늘의 메모에요!</L.BannerTitle>
+      <L.BannerText>{text}</L.BannerText>
+    </L.BannerContainer>
+  )
+}
+
+export default TodayMemo

--- a/frontend/src/pages/CalendarPage/styles/Calendar.style.tsx
+++ b/frontend/src/pages/CalendarPage/styles/Calendar.style.tsx
@@ -35,7 +35,7 @@ export const AIScheduleButton = styled.button`
 
 export const CalendarSection = styled.div`
   align-items: center;
-  height: calc(100vh - 12rem);
+  height: calc(100vh - 15rem);
 `
 
 export const WeekSection = styled.div`

--- a/frontend/src/pages/CalendarPage/styles/PlaceBox.style.tsx
+++ b/frontend/src/pages/CalendarPage/styles/PlaceBox.style.tsx
@@ -45,21 +45,19 @@ export const PlaceBoxText = styled.div<PlaceBoxTextProps>`
   line-height: 1.5rem;
   justify-content: center;
   align-items: center;
-  margin-left: ${({ isEditing }) =>
-    isEditing ? '0' : '0.5rem'}; // isEditing 상태일 때 margin 제거
+  margin-left: ${({ isEditing }) => (isEditing ? '0' : '0.5rem')};
+  margin-right: ${({ isEditing }) => (isEditing ? '1.5rem' : '0.3rem')};
 `
 
 export const PlaceBoxTitle = styled.p`
   font-weight: 700;
-  font-size: 1.1rem;
-  margin-left: 0.5rem;
+  font-size: 1rem;
 `
 
 export const PlaceBoxCity = styled.p`
   font-weight: 400;
   color: #626262;
   font-size: 0.9rem;
-  margin-left: 0.5rem;
 `
 
 export const PlaceBoxPic = styled.img`

--- a/frontend/src/pages/CalendarPage/styles/TodayMemo.style.tsx
+++ b/frontend/src/pages/CalendarPage/styles/TodayMemo.style.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components'
+
+export const BannerContainer = styled.div`
+  background-color: #eff1ff; /* 라이트 퍼플 배경 */
+  color: black;
+  padding: 10px;
+  border-radius: 5px;
+  text-align: left;
+  margin-bottom: 15px;
+  position: relative;
+  margin-left: 10px;
+  margin-right: 10px;
+`
+
+export const BannerTitle = styled.p`
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 0.2rem;
+  margin-left: 10px;
+`
+
+export const BannerText = styled.p`
+  margin: 0;
+  font-size: 12px;
+  padding: 0.2rem;
+  margin-left: 10px;
+`
+export const CloseButtonContainer = styled.button`
+  position: absolute;
+  top: 5px;
+  right: 3px;
+  height: 14px;
+  background: none;
+  text-align: right;
+  border: none;
+  width: 100%;
+  cursor: pointer;
+`
+
+export const CloseButton = styled.button`
+  position: absolute;
+
+  top: 5px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 9px;
+  cursor: pointer;
+`


### PR DESCRIPTION
## #️⃣연관된 이슈

close #145 

## 💡 핵심적으로 구현된 사항

<p>
 <img src="https://github.com/user-attachments/assets/9bdea0c2-4064-4f0f-a8cd-03c118291477" width="20%" />
 <img src="https://github.com/user-attachments/assets/646fb833-a9d5-433f-b62f-68abc1e61c4b" width="20%" />
 <img src="https://github.com/user-attachments/assets/bd3d794c-f521-4e9d-8d98-62f8f60d22ed" width="20%" />
</p>

- m 단위 삭제
- drawer 내 메모 확인의 불친절함 -> 오늘 날짜에 메모가 있을 경우 캘린더 상단에 띄워주도록 하였음
- edit 시 장소명과 아이콘 사이 간격 조정
- 장소 슬라이드 삭제 시 삭제버튼 누르면 삭제와 동시에 상세페이지 이동하는 문제 해결

## ➕ 그 외에 추가적으로 구현된 사항

없음

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영!! (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려하면 좋겠는 것들! (Comment)
* P3 : 기타 사소한 의견 (Chore) -->